### PR TITLE
Fix stackoverflows

### DIFF
--- a/src/import.ml
+++ b/src/import.ml
@@ -1,0 +1,27 @@
+(*
+ * Copyright (c) 2019-2021 Craig Ferguson <craig@tarides.com>
+ * Copyright (c) 2018-2022 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+module List = struct
+  include Stdlib.List
+
+  let map f l =
+    let rec aux acc = function
+      | [] -> acc []
+      | h :: t -> (aux [@tailcall]) (fun t' -> acc (f h :: t')) t
+    in
+    aux (fun x -> x) l
+end

--- a/src/rectangle.ml
+++ b/src/rectangle.ml
@@ -1,3 +1,5 @@
+open! Import
+
 type t = floatarray
 (* lower left x, upper right x, lower left y, upper right y*)
 
@@ -56,10 +58,11 @@ let merge arr arr' =
   Array.Floatarray.unsafe_set arr 3 (max y1 y1');
   arr
 
-let rec merge_many = function
-  | e :: [] -> e
-  | e :: es -> merge e (merge_many es)
+let merge_many t =
+  let rec loop acc = function [] -> acc | e :: es -> loop (merge e acc) es in
+  match t with
   | [] -> raise (Invalid_argument "can't zero envelopes")
+  | e :: es -> loop e es
 
 let area arr =
   let x0, x1, y0, y1 = (x0 arr, x1 arr, y0 arr, y1 arr) in

--- a/src/rtree.ml
+++ b/src/rtree.ml
@@ -1,3 +1,4 @@
+open! Import
 include Rtree_intf
 
 module Make (E : Envelope) (V : Value with type envelope = E.t) = struct

--- a/test/basic.ml
+++ b/test/basic.ml
@@ -149,6 +149,15 @@ let omt_loader () =
   let idx = R.load ~max_node_load:2 lines in
   print_endline (Repr.to_string R.t idx)
 
+let rectangle () =
+  let r1 = Rtree.Rectangle.v ~x0:(-1.) ~y0:(-1.) ~x1:1. ~y1:1. in
+  assert (r1 = Rtree.Rectangle.(merge r1 empty));
+  assert (r1 = Rtree.Rectangle.(merge_many [ r1 ]));
+  let r2 = Rtree.Rectangle.v ~x0:(-2.) ~y0:(-2.) ~x1:0. ~y1:0. in
+  let r3 = Rtree.Rectangle.v ~x0:(-2.) ~y0:(-2.) ~x1:1. ~y1:1. in
+  let r = Rtree.Rectangle.merge_many [ r1; r2 ] in
+  assert (r = r3)
+
 let suite =
   "R"
   >::: [
@@ -156,6 +165,7 @@ let suite =
          "functor" >:: test_functor;
          "lines" >:: test_lines;
          "omt" >:: omt_loader;
+         "rect" >:: rectangle;
        ]
 
 let _ = run_test_tt_main suite


### PR DESCRIPTION
Spotted by @lindig (thanks!) -- Both the use of `List.map` and the rectangle `merge_many` functions weren't tail-recursive leading to stack overflows. 