### PR TITLE
Values fix

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,2 @@
 profile=default
-version=0.26.0
+version=0.29.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.1.2 2026-05-05 Liverpool
+
+## Bugs, Fixes and Optimisations
+
+- Fix `values` not returning entire tree (#40, @mdales)
+
 # v0.1.1 2023-08-17 Cambridge
 
 ## Bugs, Fixes and Optimisations

--- a/bench/bechamel_csv.ml
+++ b/bench/bechamel_csv.ml
@@ -7,8 +7,8 @@ let pad width v =
 let pp_row ~width f data =
   data
   |> List.iteri (fun i v ->
-         if i > 0 then Fmt.comma f ();
-         Fmt.pf f "%s" (pad width.(i) v))
+      if i > 0 then Fmt.comma f ();
+      Fmt.pf f "%s" (pad width.(i) v))
 
 let pp f results =
   let results = Hashtbl.to_seq results |> Array.of_seq in
@@ -23,23 +23,23 @@ let pp f results =
   let rows =
     rows
     |> Array.map (fun name ->
-           width.(0) <- max width.(0) (String.length name + 2);
-           let values =
-             results
-             |> Array.mapi (fun i (_, col) ->
-                    let v =
-                      match Hashtbl.find col name |> Analyze.OLS.estimates with
-                      | Some [ v ] -> Printf.sprintf "%f" v
-                      | _ -> assert false
-                    in
-                    width.(i + 1) <- max width.(i + 1) (String.length v + 2);
-                    v)
-           in
-           (name, values))
+        width.(0) <- max width.(0) (String.length name + 2);
+        let values =
+          results
+          |> Array.mapi (fun i (_, col) ->
+              let v =
+                match Hashtbl.find col name |> Analyze.OLS.estimates with
+                | Some [ v ] -> Printf.sprintf "%f" v
+                | _ -> assert false
+              in
+              width.(i + 1) <- max width.(i + 1) (String.length v + 2);
+              v)
+        in
+        (name, values))
   in
   let metrics = Array.to_list results |> List.map fst in
   let headings = List.mapi (fun i v -> pad width.(i) v) ("name" :: metrics) in
   Fmt.pf f "@[<v>@[<h>%a@]" Fmt.(list ~sep:comma string) headings;
   rows
   |> Array.iter (fun (name, data) ->
-         Fmt.pf f "@,@[<h>%a@]" (pp_row ~width) (name :: Array.to_list data))
+      Fmt.pf f "@,@[<h>%a@]" (pp_row ~width) (name :: Array.to_list data))

--- a/src/rtree.ml
+++ b/src/rtree.ml
@@ -153,8 +153,8 @@ module Make (E : Envelope) (V : Value with type envelope = E.t) = struct
 
   let rec values' acc = function
     | Node lst -> List.fold_left (fun a (_, v) -> values' a v) acc lst
-    | Leaf vs -> List.map snd vs
-    | Empty -> []
+    | Leaf vs -> (List.map snd vs) @ acc
+    | Empty -> acc
 
   let values t = values' [] t.tree
   let log_base b n = log n /. log b

--- a/src/rtree.ml
+++ b/src/rtree.ml
@@ -11,7 +11,9 @@ module Make (E : Envelope) (V : Value with type envelope = E.t) = struct
     let open Repr in
     mu (fun tree ->
         variant "tree_t" (fun node leaf empty -> function
-          | Node lst -> node lst | Leaf s -> leaf s | Empty -> empty)
+          | Node lst -> node lst
+          | Leaf s -> leaf s
+          | Empty -> empty)
         |~ case1 "Node" (list (pair E.t tree)) (fun x -> Node x)
         |~ case1 "Leaf" (list (pair E.t V.t)) (fun x -> Leaf x)
         |~ case0 "Empty" Empty |> sealv)
@@ -153,7 +155,7 @@ module Make (E : Envelope) (V : Value with type envelope = E.t) = struct
 
   let rec values' acc = function
     | Node lst -> List.fold_left (fun a (_, v) -> values' a v) acc lst
-    | Leaf vs -> (List.map snd vs) @ acc
+    | Leaf vs -> List.map snd vs @ acc
     | Empty -> acc
 
   let values t = values' [] t.tree

--- a/src/rtree_intf.ml
+++ b/src/rtree_intf.ml
@@ -1,34 +1,33 @@
 module type Value = sig
-  (** Values are stored in the Rtree and must provide a means
-      of calculating an envelope (minimal bounding box).
+  (** Values are stored in the Rtree and must provide a means of calculating an
+      envelope (minimal bounding box).
 
       {2 An example}
-      A two-dimensional lines that uses {! Rectangle} as a bounding
-      box could be implemented as
+      A two-dimensional lines that uses {! Rectangle} as a bounding box could be
+      implemented as
       {[
-        module Line = struct
-          type t = { p0 : float * float; p1 : float * float }
+      module Line = struct
+        type t = { p0 : float * float; p1 : float * float }
 
-          let t =
-            let open Repr in
-            record "line" (fun p0 p1 -> { p0; p1 })
-            |+ field "p0" (pair float float) (fun t -> t.p0)
-            |+ field "p1" (pair float float) (fun t -> t.p1)
-            |> sealr
+        let t =
+          let open Repr in
+          record "line" (fun p0 p1 -> { p0; p1 })
+          |+ field "p0" (pair float float) (fun t -> t.p0)
+          |+ field "p1" (pair float float) (fun t -> t.p1)
+          |> sealr
 
-          type envelope = Rtree.Rectangle.t
+        type envelope = Rtree.Rectangle.t
 
-          let envelope { p0 = (x1, y1); p1 = (x2, y2) } =
-            let x0 = Float.min x1 x2 in
-            let x1 = Float.max x1 x2 in
-            let y0 = Float.min y1 y2 in
-            let y1 = Float.max y1 y2 in
-            Rtree.Rectangle.v ~x0 ~y0 ~x1 ~y1
-        end
+        let envelope { p0 = x1, y1; p1 = x2, y2 } =
+          let x0 = Float.min x1 x2 in
+          let x1 = Float.max x1 x2 in
+          let y0 = Float.min y1 y2 in
+          let y1 = Float.max y1 y2 in
+          Rtree.Rectangle.v ~x0 ~y0 ~x1 ~y1
+      end
       ]}
 
-      Note that a runtime representation must also be provided.
-      *)
+      Note that a runtime representation must also be provided. *)
 
   (** {2 Interface} *)
 
@@ -102,8 +101,8 @@ module type S = sig
       same representation used internally. *)
 
   val empty : int -> t
-  (** The empty tree configured with a maximum load size. This
-      is the number of children allowed at a level. *)
+  (** The empty tree configured with a maximum load size. This is the number of
+      children allowed at a level. *)
 
   val insert : t -> Value.t -> t
   (** Insert a new element into the tree *)
@@ -118,18 +117,18 @@ module type S = sig
   (** Returns all the values currently in the index. *)
 
   val load : ?max_node_load:int -> Value.t list -> t
-  (** [load vs] will "bulk" load values into an r-tree. This will produce
-      a better tree and is preferred over folding with {! insert}.
+  (** [load vs] will "bulk" load values into an r-tree. This will produce a
+      better tree and is preferred over folding with {! insert}.
 
-      It uses the {{: https://ceur-ws.org/Vol-74/files/FORUM_18.pdf} OMT algorithm}. *)
+      It uses the
+      {{:https://ceur-ws.org/Vol-74/files/FORUM_18.pdf} OMT algorithm}. *)
 
   val depth : t -> int
   (** [depth tree] returns the depth of the tree. *)
 
   val iter : t -> (tree -> unit) -> unit
-  (** [iter tree f] will apply [f] to every internal tree node in [t].
-      For a {! Node} this will first apply [f] then descend into the
-      children. *)
+  (** [iter tree f] will apply [f] to every internal tree node in [t]. For a
+      {! Node} this will first apply [f] then descend into the children. *)
 end
 
 module type Maker = functor

--- a/test/basic.ml
+++ b/test/basic.ml
@@ -131,7 +131,9 @@ let omt_loader () =
     ]
   in
   let idx = R.load ~max_node_load:2 lines in
-  print_endline (Repr.to_string R.t idx)
+  print_endline (Repr.to_string R.t idx);
+  let vs = R.values idx in
+  assert (List.length vs = 4)
 
 let rectangle () =
   let r1 = Rtree.Rectangle.v ~x0:(-1.) ~y0:(-1.) ~x1:1. ~y1:1. in

--- a/test/basic.ml
+++ b/test/basic.ml
@@ -64,8 +64,7 @@ let test_functor _ =
         type envelope = Rtree.Rectangle.t
 
         let envelope i = List.assoc i elems
-      end)
-  in
+      end) in
   let r =
     List.fold_left (fun r (i, _envelope) -> R.insert r i) (R.empty 8) elems
   in
@@ -162,8 +161,7 @@ let test_iter () =
           let y0 = Float.min y1 y2 in
           let y1 = Float.max y1 y2 in
           Rtree.Rectangle.v ~x0 ~y0 ~x1 ~y1
-      end)
-  in
+      end) in
   let lines =
     [
       { p1 = (0., 0.); p2 = (1., 1.) };
@@ -208,8 +206,7 @@ let test_depth () =
           let y0 = Float.min y1 y2 in
           let y1 = Float.max y1 y2 in
           Rtree.Rectangle.v ~x0 ~y0 ~x1 ~y1
-      end)
-  in
+      end) in
   let lines =
     [
       { p1 = (0., 0.); p2 = (1., 1.) };


### PR DESCRIPTION
The `values` function to get the contents of the tree didn't track the accumulator properly (#40). This PR updates an existing test to exercise the bug (the test fails without the fix) and then applies the fix.

Ocamlformat was also on 0.26 vs the current 0.29, so I updated that too - but the changes are in seperate commits to hopefully make review easier.